### PR TITLE
Rate limiting, count moved to redis

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -1,22 +1,43 @@
 <script lang="ts">
   import { ClackerClient } from "./ClackerClient";
   import {ClientStateStore} from './ClientStateStore';
+  import ClackerName from './ClackerName.svelte';
 
   const client = new ClackerClient($ClientStateStore.user);
 
   function clackConfection() {
     client.sendClack();
   }
+
+  let rateLimited = false;
+  $: rateLimited = isRateLimited($ClientStateStore.nextRefresh);
+
+  function isRateLimited(nextRefresh: number): boolean {
+    const dateNow = Date.now();
+    const delta = nextRefresh - dateNow;
+    const result = delta >= 0;
+    if (result) {
+      setTimeout(() => {ClientStateStore.update(state => ({...state, nextRefresh: 0}))}, delta);
+    }
+    return result;
+  }
+
+  function onUserChange() {
+    client.sendIdentity($ClientStateStore.user);
+  }
 </script>
 
 <main>
   <h1>Confection Clacker</h1>
   <button id='confection' on:click={clackConfection}>
-    <img src='confection.png' alt='A cookie with pastel pink icing and some sprinkles'>
+    <img style='height: 30vh' src='confection.png' alt='A cookie with pastel pink icing and some sprinkles'>
   </button>
   <p id='clack-count'>Confections clacked: {$ClientStateStore.count}</p>
+  <ClackerName on:change={onUserChange} />
   {#if !$ClientStateStore.connected}
     <p id='error'>(Not connected to server.)</p>
+  {:else if rateLimited}
+    <p id='error'>You're clacking too quickly! Please wait.</p>
   {/if}
 </main>
 

--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -35,7 +35,7 @@
   <p id='clack-count'>Confections clacked: {$ClientStateStore.count}</p>
   <ClackerName on:change={onUserChange} />
   {#if !$ClientStateStore.connected}
-    <p id='error'>(Not connected to server.)</p>
+    <p id='error'>Not connected to server. Try refreshing, or come back later.</p>
   {:else if rateLimited}
     <p id='error'>You're clacking too quickly! Please wait.</p>
   {/if}

--- a/client/src/ClackerName.svelte
+++ b/client/src/ClackerName.svelte
@@ -1,0 +1,11 @@
+<script lang='ts'>
+  import { onMount } from "svelte";
+  import App from "./App.svelte";
+  import { ClientStateStore } from "./ClientStateStore";
+</script>
+
+<input bind:value={$ClientStateStore.user} on:change>
+
+<style>
+
+</style>

--- a/client/src/ClientState.ts
+++ b/client/src/ClientState.ts
@@ -2,10 +2,12 @@ export type ClientState = {
   count: number;
   connected: boolean;
   user: string;
+  nextRefresh: number;
 };
 
 export const ClientStateDefault: () => ClientState = () => ({
   count: 0,
   connected: false,
-  user: 'Clacker'
+  user: 'Clacker',
+  nextRefresh: 0
 });

--- a/common/Message.ts
+++ b/common/Message.ts
@@ -1,7 +1,8 @@
 export enum MessageType {
   Identity = 0x00,
   Clack = 0x01,
-  Count = 0x02
+  Count = 0x02,
+  RateLimit = 0x03,
 }
 
 export class Message {
@@ -33,5 +34,14 @@ export class MessageCount extends Message {
   constructor(count: number) {
     super(MessageType.Count);
     this.count = count;
+  }
+}
+
+export class MessageRateLimit extends Message {
+  nextRefresh: number;
+
+  constructor(nextRefresh: number) {
+    super(MessageType.RateLimit);
+    this.nextRefresh = nextRefresh;
   }
 }

--- a/server/ClackRateLimiter.ts
+++ b/server/ClackRateLimiter.ts
@@ -1,0 +1,29 @@
+import {redis} from './redis';
+
+export class ClackRateLimiter {
+  requestLimit: number = 10;
+  requestWindow: number = 1000;
+  nextRefresh: number = Date.now() + this.requestWindow;
+
+  constructor(requestLimit?: number, requestWindow?: number) {
+    if (requestLimit) this.requestLimit = requestLimit;
+    if (requestWindow) this.requestWindow = requestWindow;
+
+    setInterval(this.refresh.bind(this), this.requestWindow);
+  }
+
+  async refresh() {
+    this.nextRefresh = Date.now() + this.requestWindow;
+    const keys = await redis.keys('user_*');
+    if (keys.length) await redis.del(keys);
+  }
+
+  async request(user: string): Promise<boolean> {
+    const userKey = `user_${user}`;
+    redis.setnx(userKey, '0');
+    const requestsMade = parseInt(await redis.get(userKey) ?? 'Infinity');
+    if (requestsMade >= this.requestLimit) return false;
+    redis.incr(userKey);
+    return true;
+  }
+}

--- a/server/ClackStore.ts
+++ b/server/ClackStore.ts
@@ -1,0 +1,18 @@
+import { Redis } from "ioredis";
+
+export class ClackStore {
+  redis
+
+  constructor(redis: Redis) {
+    this.redis = redis;
+    this.redis.setnx('clackCount', 0);
+  }
+
+  async incr() {
+    return this.redis.incr('clackCount');
+  }
+
+  async getCount(): Promise<number> {
+    return parseInt(await this.redis.get('clackCount') ?? '0');
+  }
+}

--- a/server/ClackStore.ts
+++ b/server/ClackStore.ts
@@ -1,7 +1,7 @@
 import { Redis } from "ioredis";
 
 export class ClackStore {
-  redis
+  redis: Redis;
 
   constructor(redis: Redis) {
     this.redis = redis;

--- a/server/Client.ts
+++ b/server/Client.ts
@@ -5,7 +5,7 @@ import { Message, MessageIdentity, MessageType } from '../common/Message';
 export class Client {
   socket: WS;
   info: ClientInfo | null = null;
-  onClack: (() => void) | null = null;
+  onClack: ((client: Client) => void) | null = null;
   onClose: ((clientToClose: Client) => void) | null = null;
 
   constructor(socket: WS) {
@@ -38,6 +38,6 @@ export class Client {
 
   clack() {
     if (!this.onClack) return;
-    this.onClack();
+    this.onClack(this);
   }
 }

--- a/server/ServerState.ts
+++ b/server/ServerState.ts
@@ -1,7 +1,0 @@
-export class ServerState {
-  clackCount: number = 0;
-
-  constructor() {
-    
-  }
-}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,6 @@
+name: confection-clacker
+services:
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379

--- a/server/redis.ts
+++ b/server/redis.ts
@@ -1,0 +1,4 @@
+import Redis from 'ioredis';
+
+export const redis = new Redis();
+redis.setnx('clackCount', '0');

--- a/server/redis.ts
+++ b/server/redis.ts
@@ -1,4 +1,3 @@
 import Redis from 'ioredis';
 
 export const redis = new Redis();
-redis.setnx('clackCount', '0');


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5dc32538bb5d7e5a2a5aee6a944d2f911a958b0c  | 
|--------|--------|

### Summary:
Introduced rate limiting for clack requests and moved clack count storage to Redis.

**Key points**:
- Added rate limiting for clack requests in `server/ClackRateLimiter.ts`.
- Moved clack count storage to Redis in `server/ClackStore.ts`.
- Updated `client/src/App.svelte` to display rate limit messages.
- Modified `client/src/ClackerClient.ts` to handle rate limit messages.
- Added `MessageRateLimit` class in `common/Message.ts`.
- Updated server to use Redis for clack counts and rate limits in `server/server.ts`.
- Added Docker Compose file for Redis setup in `server/docker-compose.yml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->